### PR TITLE
feat: add GitHub Actions workflow for automated publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm run build
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: pnpm run release
+          title: "chore: release package"
+          commit: "chore: release package"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "typecheck": "tsc --noEmit",
+    "release": "changeset publish",
     "prepare": "husky",
     "prepublishOnly": "pnpm run build",
     "commit-wip": "git commit --no-verify -m \"WIP: Work in progress commit\""


### PR DESCRIPTION
## Summary

Adds the missing GitHub Actions workflow for automated package publishing using Changesets.

## Changes

- Added `.github/workflows/release.yml` for automated releases
- Added `release` script to `package.json` 
- Workflow triggers on pushes to main branch
- Uses `changesets/action` to create release PRs and publish to npm

## How it works

1. When this PR is merged, the workflow will detect the existing changeset
2. It will create a release PR with version bumps and changelog
3. When the release PR is merged, it will automatically publish to npm

## Required Secrets

The workflow expects these GitHub secrets to be configured:
- `NPM_TOKEN` - for publishing to npm (should already be set)
- `GITHUB_TOKEN` - for creating PRs (automatically provided)

🤖 Generated with Claude Code