### PR TITLE
fix: update GitHub Actions to use Node.js 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 18
+      - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Quick fix for the Node.js version in GitHub Actions workflow.

## Issue
The current workflow uses Node.js 18, but dependencies require Node.js 20+, causing deployment failures with error:
\\\

## Fix
- Update GitHub Actions workflow from Node.js 18 → Node.js 20
- This resolves the dependency compatibility issue

**Urgent:** Needed to fix the current deployment failure.

🤖 Generated with Claude Code