### PR TITLE
fix: correct package name to match organization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@astral-protocol/sdk",
+  "name": "@decentralized-geo/astral-sdk",
   "version": "0.1.0",
   "description": "Astral's Location Proof Protocol SDK",
   "main": "dist/index.js",


### PR DESCRIPTION
Fixes the package name mismatch causing changesets to fail.

## Issue
Changesets error: \

## Root Cause
Package name mismatch:
- package.json had: \  
- changeset expected: \

## Fix
- Updated package.json to use \
- Ensures changesets can find the package in workspace
- Maintains clean v0.1.0 version (no version bump)

**Urgent:** Required for deployment to work.

🤖 Generated with Claude Code