### PR TITLE
fix: add publishConfig access public for scoped package

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
   ],
   "author": "Astral Protocol",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@ethereum-attestation-service/eas-sdk": "^2.7.0",
     "@turf/boolean-valid": "7.2.0",


### PR DESCRIPTION
Fixes npm 402 error by explicitly setting publishConfig.access to 'public' for the scoped @decentralized-geo/astral-sdk package.