### PR TITLE
Refactor EAS-config to exist in source

### DIFF
--- a/config/EAS-config.json
+++ b/config/EAS-config.json
@@ -1,5 +1,5 @@
 {
-  "v0.1":{
+  "v0.1": {
     "schema": {
       "interface": {
         "eventTimestamp": "uint256",
@@ -43,7 +43,6 @@
         "easContractAddress": "0x4200000000000000000000000000000000000021",
         "schemaUID": "0xba4171c92572b1e4f241d044c32cdf083be9fd946b8766977558ca6378c824e2"
       }
-
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,5 +92,6 @@
       "eslint --fix",
       "prettier --write"
     ]
-  }
+  },
+  "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,0 +1,83 @@
+/**
+ * Interface for EAS schema configuration
+ */
+export interface EASSchemaConfig {
+  interface: Record<string, string>;
+  rawString: string;
+}
+
+/**
+ * Interface for EAS chain configuration
+ */
+export interface EASChainConfig {
+  chain: string;
+  deploymentBlock: number;
+  rpcUrl: string;
+  easContractAddress: string;
+  schemaUID: string;
+}
+
+/**
+ * Interface for version-specific EAS configuration
+ */
+export interface EASVersionConfig {
+  schema: EASSchemaConfig;
+  chains: Record<string, EASChainConfig>;
+}
+
+/**
+ * Complete EAS configuration with version support
+ */
+export interface EASConfig {
+  [version: string]: EASVersionConfig;
+}
+
+export const EAS_CONFIG: EASConfig = {
+  'v0.1': {
+    schema: {
+      interface: {
+        eventTimestamp: 'uint256',
+        srs: 'string',
+        locationType: 'string',
+        location: 'string',
+        recipeType: 'string[]',
+        recipePayload: 'bytes[]',
+        mediaType: 'string[]',
+        mediaData: 'string[]',
+        memo: 'string',
+      },
+      rawString:
+        'uint256 eventTimestamp,string srs,string locationType,string location,string[] recipeType,bytes[] recipePayload,string[] mediaType,string[] mediaData,string memo',
+    },
+    chains: {
+      '42220': {
+        chain: 'celo',
+        deploymentBlock: 26901063,
+        rpcUrl: 'https://celo-mainnet.infura.io/v3/',
+        easContractAddress: '0x72E1d8ccf5299fb36fEfD8CC4394B8ef7e98Af92',
+        schemaUID: '0xba4171c92572b1e4f241d044c32cdf083be9fd946b8766977558ca6378c824e2',
+      },
+      '42161': {
+        chain: 'arbitrum',
+        deploymentBlock: 243446573,
+        rpcUrl: 'https://arbitrum-mainnet.infura.io/v3/',
+        easContractAddress: '0xbD75f629A22Dc1ceD33dDA0b68c546A1c035c458',
+        schemaUID: '0xba4171c92572b1e4f241d044c32cdf083be9fd946b8766977558ca6378c824e2',
+      },
+      '11155111': {
+        chain: 'sepolia',
+        deploymentBlock: 6269763,
+        rpcUrl: 'https://sepolia.infura.io/v3/',
+        easContractAddress: '0xC2679fBD37d54388Ce493F1DB75320D236e1815e',
+        schemaUID: '0xba4171c92572b1e4f241d044c32cdf083be9fd946b8766977558ca6378c824e2',
+      },
+      '8453': {
+        chain: 'base',
+        deploymentBlock: 25903221,
+        rpcUrl: 'https://base-mainnet.infura.io/v3/',
+        easContractAddress: '0x4200000000000000000000000000000000000021',
+        schemaUID: '0xba4171c92572b1e4f241d044c32cdf083be9fd946b8766977558ca6378c824e2',
+      },
+    },
+  },
+};

--- a/src/eas/chains.ts
+++ b/src/eas/chains.ts
@@ -24,7 +24,7 @@ let cachedConfig: EASConfig | null = null;
 /**
  * Loads the EAS configuration from the config file
  *
- * @param configPath - Optional custom path to the config file
+ * @param configPath - Optional custom path to the config file (defaults to null, which uses the default EAS_CONFIG)
  * @returns The parsed EAS configuration
  * @throws {ChainConnectionError} If the config file cannot be loaded or parsed
  */

--- a/src/eas/chains.ts
+++ b/src/eas/chains.ts
@@ -9,45 +9,14 @@
  */
 
 import * as fs from 'fs';
-import * as path from 'path';
 import { ChainConnectionError } from '../core/errors';
-
-/**
- * Interface for EAS schema configuration
- */
-export interface EASSchemaConfig {
-  interface: Record<string, string>;
-  rawString: string;
-}
-
-/**
- * Interface for EAS chain configuration
- */
-export interface EASChainConfig {
-  chain: string;
-  deploymentBlock: number;
-  rpcUrl: string;
-  easContractAddress: string;
-  schemaUID: string;
-}
-
-/**
- * Interface for version-specific EAS configuration
- */
-export interface EASVersionConfig {
-  schema: EASSchemaConfig;
-  chains: Record<string, EASChainConfig>;
-}
-
-/**
- * Complete EAS configuration with version support
- */
-export interface EASConfig {
-  [version: string]: EASVersionConfig;
-}
-
-// Default path to the EAS configuration file
-const CONFIG_PATH = path.resolve(process.cwd(), 'config', 'EAS-config.json');
+import {
+  EAS_CONFIG,
+  EASChainConfig,
+  EASConfig,
+  EASSchemaConfig,
+  EASVersionConfig,
+} from '@/core/config';
 
 // Cache the loaded configuration
 let cachedConfig: EASConfig | null = null;
@@ -59,7 +28,9 @@ let cachedConfig: EASConfig | null = null;
  * @returns The parsed EAS configuration
  * @throws {ChainConnectionError} If the config file cannot be loaded or parsed
  */
-export function loadEASConfig(configPath: string = CONFIG_PATH): EASConfig {
+export function loadEASConfig(configPath: string | null = null): EASConfig {
+  if (!configPath) return EAS_CONFIG;
+
   // Return cached config if available and not in test mode
   if (cachedConfig !== null && process.env.NODE_ENV !== 'test') {
     return cachedConfig;

--- a/test/eas/chains.test.ts
+++ b/test/eas/chains.test.ts
@@ -18,9 +18,9 @@ import {
   getSupportedChainNames,
   getSchemaConfig,
   getSchemaUID,
-  EASConfig,
 } from '../../src/eas/chains';
 import { ChainConnectionError } from '../../src/core/errors';
+import { EASConfig } from '@/core/config';
 
 // Mock the configuration for testing
 const mockConfig: EASConfig = {

--- a/test/eas/chains.test.ts
+++ b/test/eas/chains.test.ts
@@ -41,11 +41,11 @@ const mockConfig: EASConfig = {
         'uint256 eventTimestamp,string srs,string locationType,string location,string[] recipeType,bytes[] recipePayload,string[] mediaType,string[] mediaData,string memo',
     },
     chains: {
-      '11155111': {
-        chain: 'sepolia',
-        deploymentBlock: 6269763,
-        rpcUrl: 'https://sepolia.infura.io/v3/',
-        easContractAddress: '0xC2679fBD37d54388Ce493F1DB75320D236e1815e',
+      '42220': {
+        chain: 'celo',
+        deploymentBlock: 26901063,
+        rpcUrl: 'https://celo-mainnet.infura.io/v3/',
+        easContractAddress: '0x72E1d8ccf5299fb36fEfD8CC4394B8ef7e98Af92',
         schemaUID: '0xba4171c92572b1e4f241d044c32cdf083be9fd946b8766977558ca6378c824e2',
       },
       '42161': {
@@ -55,26 +55,6 @@ const mockConfig: EASConfig = {
         easContractAddress: '0xbD75f629A22Dc1ceD33dDA0b68c546A1c035c458',
         schemaUID: '0xba4171c92572b1e4f241d044c32cdf083be9fd946b8766977558ca6378c824e2',
       },
-    },
-  },
-  'v0.2': {
-    schema: {
-      interface: {
-        eventTimestamp: 'uint256',
-        srs: 'string',
-        locationType: 'string',
-        location: 'string',
-        recipeType: 'string[]',
-        recipePayload: 'bytes[]',
-        mediaType: 'string[]',
-        mediaData: 'string[]',
-        memo: 'string',
-        extra: 'string',
-      },
-      rawString:
-        'uint256 eventTimestamp,string srs,string locationType,string location,string[] recipeType,bytes[] recipePayload,string[] mediaType,string[] mediaData,string memo,string extra',
-    },
-    chains: {
       '11155111': {
         chain: 'sepolia',
         deploymentBlock: 6269763,
@@ -125,8 +105,7 @@ describe('EAS Chain Configuration', () => {
     it('should load and parse the configuration file', () => {
       const config = loadEASConfig();
 
-      expect(fs.readFileSync).toHaveBeenCalled();
-      expect(config).toEqual(mockConfig);
+      expect(JSON.stringify(config)).toEqual(JSON.stringify(mockConfig));
     });
 
     it('should throw ChainConnectionError if the file cannot be read', () => {
@@ -134,8 +113,8 @@ describe('EAS Chain Configuration', () => {
         throw new Error('File not found');
       });
 
-      expect(() => loadEASConfig()).toThrow(ChainConnectionError);
-      expect(() => loadEASConfig()).toThrow('Failed to load EAS configuration');
+      expect(() => loadEASConfig('./invaliddir')).toThrow(ChainConnectionError);
+      expect(() => loadEASConfig('./invaliddir')).toThrow('Failed to load EAS configuration');
     });
   });
 
@@ -143,7 +122,7 @@ describe('EAS Chain Configuration', () => {
     it('should return the latest version configuration', () => {
       const versionConfig = getLatestVersionConfig(mockConfig);
 
-      expect(versionConfig).toEqual(mockConfig['v0.2']);
+      expect(versionConfig).toEqual(mockConfig['v0.1']);
     });
 
     it('should throw ChainConnectionError if no versions are available', () => {
@@ -171,7 +150,7 @@ describe('EAS Chain Configuration', () => {
     it('should return the configuration for a specific chain ID', () => {
       const chainConfig = getChainConfig(11155111);
 
-      expect(chainConfig).toEqual(mockConfig['v0.2'].chains['11155111']);
+      expect(chainConfig).toEqual(mockConfig['v0.1'].chains['11155111']);
     });
 
     it('should return the configuration for a specific chain ID and version', () => {
@@ -190,13 +169,13 @@ describe('EAS Chain Configuration', () => {
     it('should return the configuration for a specific chain name', () => {
       const chainConfig = getChainConfigByName('sepolia');
 
-      expect(chainConfig).toEqual(mockConfig['v0.2'].chains['11155111']);
+      expect(chainConfig).toEqual(mockConfig['v0.1'].chains['11155111']);
     });
 
     it('should be case-insensitive when matching chain names', () => {
       const chainConfig = getChainConfigByName('SePoLiA');
 
-      expect(chainConfig).toEqual(mockConfig['v0.2'].chains['11155111']);
+      expect(chainConfig).toEqual(mockConfig['v0.1'].chains['11155111']);
     });
 
     it('should throw ChainConnectionError if the chain name is not supported', () => {
@@ -213,7 +192,7 @@ describe('EAS Chain Configuration', () => {
     });
 
     it('should be case-insensitive when matching chain names', () => {
-      const chainId = getChainId('BaSe', 'v0.2');
+      const chainId = getChainId('BaSe', 'v0.1');
 
       expect(chainId).toBe(8453);
     });
@@ -248,7 +227,7 @@ describe('EAS Chain Configuration', () => {
       const chainIds = getSupportedChainIds();
 
       // IDs should be returned in ascending order
-      expect(chainIds).toEqual([8453, 11155111]);
+      expect(chainIds).toEqual([8453, 42161, 42220, 11155111]);
     });
 
     it('should return all supported chain IDs for a specific version', () => {
@@ -257,7 +236,7 @@ describe('EAS Chain Configuration', () => {
       // Since we're testing with mock data, we should expect what's in the mock, not the real config
       expect(chainIds).toContain(11155111);
       expect(chainIds).toContain(42161);
-      expect(chainIds.length).toBe(2);
+      expect(chainIds.length).toBe(4);
     });
   });
 
@@ -266,14 +245,14 @@ describe('EAS Chain Configuration', () => {
       const chainNames = getSupportedChainNames();
 
       // Names should be alphabetically sorted
-      expect(chainNames).toEqual(['base', 'sepolia']);
+      expect(chainNames).toEqual(['arbitrum', 'base', 'celo', 'sepolia']);
     });
 
     it('should return all supported chain names for a specific version', () => {
       const chainNames = getSupportedChainNames('v0.1');
 
       // Names should be alphabetically sorted
-      expect(chainNames).toEqual(['arbitrum', 'sepolia']);
+      expect(chainNames).toEqual(['arbitrum', 'base', 'celo', 'sepolia']);
     });
   });
 
@@ -281,7 +260,7 @@ describe('EAS Chain Configuration', () => {
     it('should return the schema configuration for the latest version', () => {
       const schemaConfig = getSchemaConfig();
 
-      expect(schemaConfig).toEqual(mockConfig['v0.2'].schema);
+      expect(schemaConfig).toEqual(mockConfig['v0.1'].schema);
     });
 
     it('should return the schema configuration for a specific version', () => {


### PR DESCRIPTION
This PR refactors the implementation of loading the EAS-config. Instead of defaulting to `fs.readFileSync`, the config is instead exported as a variable by default and used when the `configPath` is null when calling `loadEASConfig`.

## Rationale

In a production environment, when attempting to use the astral SDK, I run into `Error in main function: Error [ChainConnectionError]: Failed to load EAS configuration from /Users/{USER}/Documents/code/easier/eas-sandbox/config/EAS-config.json`. This is because `readFileSync` appears to use the relative path of the project entry point rather than the bundled library. With this new implementation, this error should no longer be thrown and still offer end-users to load their own config.

## What's changed

1. Added new `config.ts` file in `src/core` that exports `EAS_CONFIG`
2. Default export of `EAS_CONFIG` when configPath is defined