### PR TITLE
Removed packageManager property

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,5 @@
       "eslint --fix",
       "prettier --write"
     ]
-  },
-  "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"
+  }
 }


### PR DESCRIPTION
This pull request includes a minor change to the `package.json` file. The `packageManager` field specifying the use of `pnpm` has been removed.

References #27 