### PR TITLE
feat: self-contained quickstart examples (v0.1.2)

### DIFF
--- a/.changeset/sharp-pans-nail.md
+++ b/.changeset/sharp-pans-nail.md
@@ -1,0 +1,12 @@
+---
+"@decentralized-geo/astral-sdk": patch
+---
+
+Update quickstart examples to be self-contained
+
+- Replace window.ethereum with ethers Wallet creation in all examples
+- Make quickstart work without browser wallet requirement  
+- Use GeoJSON format consistently (coordinate arrays not yet supported)
+- Clear distinction between offchain (no provider) and onchain (with provider)
+
+This ensures developers can run examples immediately without external dependencies.

--- a/README.md
+++ b/README.md
@@ -42,11 +42,15 @@ npm install @decentralized-geo/astral-sdk
 
 ```typescript
 import { AstralSDK } from '@decentralized-geo/astral-sdk';
+import { Wallet } from 'ethers';
 
-// Connect to your wallet
+// Create a test wallet (for production, use your actual wallet)
+const privateKey = Wallet.createRandom().privateKey;
+const wallet = new Wallet(privateKey);
+
+// Initialize SDK with the signer
 const sdk = new AstralSDK({ 
-  provider: window.ethereum,
-  chainId: 11155111 // Sepolia testnet
+  signer: wallet
 });
 
 // Create a signed location record
@@ -80,8 +84,19 @@ if (result.isValid) {
 ### Store records permanently on blockchain
 
 ```typescript
+import { JsonRpcProvider } from 'ethers';
+
+// For blockchain storage, you need a provider
+const provider = new JsonRpcProvider('https://sepolia.infura.io/v3/YOUR_INFURA_KEY');
+const walletWithProvider = wallet.connect(provider);
+
+const sdkWithProvider = new AstralSDK({
+  signer: walletWithProvider,
+  chainId: 11155111 // Sepolia testnet
+});
+
 // Same API, but stores on blockchain forever
-const onchainRecord = await sdk.createOnchainLocationAttestation({
+const onchainRecord = await sdkWithProvider.createOnchainLocationAttestation({
   location: {
     type: 'Polygon',
     coordinates: [[

--- a/docs/quick-start/configuration.md
+++ b/docs/quick-start/configuration.md
@@ -10,15 +10,19 @@ Connect the SDK to your Web3 wallet and choose your network.
 
 ## Basic Configuration
 
-The simplest setup uses your browser wallet:
+The simplest setup creates a test wallet:
 
 ```typescript
 import { AstralSDK } from '@decentralized-geo/astral-sdk';
+import { Wallet } from 'ethers';
 
-// Connect to browser wallet (MetaMask, etc.)
+// Create a test wallet (for production, use your actual wallet)
+const privateKey = Wallet.createRandom().privateKey;
+const wallet = new Wallet(privateKey);
+
+// Initialize SDK with the signer
 const sdk = new AstralSDK({ 
-  provider: window.ethereum,
-  defaultChain: 'sepolia' // testnet for development
+  signer: wallet
 });
 ```
 
@@ -39,10 +43,10 @@ type SupportedChain =
 ```typescript
 const sdk = new AstralSDK({
   // Required
-  provider: window.ethereum,          // Web3 provider
+  signer: wallet,                    // Wallet signer
   
   // Optional
-  defaultChain: 'sepolia',           // Default: 'sepolia'
+  chainId: 11155111,                 // Chain ID (11155111 = Sepolia)
   apiUrl: 'https://api.astral.com',  // Custom API endpoint
   debug: true                        // Enable debug logging
 });
@@ -50,26 +54,28 @@ const sdk = new AstralSDK({
 
 ## Provider Options
 
-### Browser Wallet (Recommended)
+### For Offchain Attestations (No Gas)
 
 ```typescript
-// MetaMask or other injected wallets
+// Simple wallet without provider - perfect for offchain attestations
+const wallet = new Wallet(privateKey);
 const sdk = new AstralSDK({ 
-  provider: window.ethereum 
+  signer: wallet 
 });
 ```
 
-### Custom Provider
+### For Onchain Attestations (Requires Gas)
 
 ```typescript
-import { ethers } from 'ethers';
+import { JsonRpcProvider } from 'ethers';
 
-// Using ethers.js provider
-const provider = new ethers.JsonRpcProvider('https://rpc.sepolia.org');
-const signer = new ethers.Wallet(privateKey, provider);
+// Connect wallet to provider for blockchain transactions
+const provider = new JsonRpcProvider('https://sepolia.infura.io/v3/YOUR_KEY');
+const walletWithProvider = wallet.connect(provider);
 
 const sdk = new AstralSDK({ 
-  provider: signer 
+  signer: walletWithProvider,
+  chainId: 11155111 // Sepolia
 });
 ```
 

--- a/docs/quick-start/first-attestation.md
+++ b/docs/quick-start/first-attestation.md
@@ -14,16 +14,23 @@ Start with an offchain attestation - no blockchain fees required:
 
 ```typescript
 import { AstralSDK } from '@decentralized-geo/astral-sdk';
+import { Wallet } from 'ethers';
+
+// Create a test wallet (for production, use your actual wallet)
+const privateKey = Wallet.createRandom().privateKey;
+const wallet = new Wallet(privateKey);
 
 // Initialize SDK
 const sdk = new AstralSDK({ 
-  provider: window.ethereum,
-  defaultChain: 'sepolia' 
+  signer: wallet
 });
 
 // Create attestation
 const attestation = await sdk.createOffchainLocationAttestation({
-  location: [-0.163808, 51.5101], // [lng, lat]
+  location: {
+    type: 'Point',
+    coordinates: [-0.163808, 51.5101] // [lng, lat]
+  },
   memo: 'Westminster Bridge, London'
 });
 


### PR DESCRIPTION
## Summary
Updates all quickstart examples to be self-contained and runnable without external dependencies.

## Changes
- Replace all `window.ethereum` references with ethers Wallet creation
- Update examples to use GeoJSON format (coordinate arrays not yet supported)
- Clear distinction between offchain (no provider) and onchain (with provider) workflows
- Add changeset for version management (will bump to v0.1.2 on release)

## Why This Matters
Previously, quickstart examples required users to have MetaMask or another browser wallet configured. This created friction for developers trying to quickly test the SDK. Now they can copy-paste and run examples immediately.

## Examples Updated
- README.md quickstart
- docs/quick-start/configuration.md
- docs/quick-start/first-attestation.md

## Version Management
This PR includes a changeset file that will bump the version to 0.1.2 when released using the project's changeset workflow.

## Test Plan
- [x] All examples use self-contained wallet creation
- [x] Examples clearly show when a provider is needed (onchain) vs not (offchain)
- [x] All examples use supported GeoJSON format
- [x] Changeset added for patch version bump

🤖 Generated with [Claude Code](https://claude.ai/code)