### PR TITLE
feat: wire SDK to hosted verification service

### DIFF
--- a/src/AstralSDK.ts
+++ b/src/AstralSDK.ts
@@ -114,7 +114,7 @@ export class AstralSDK {
 
     // Initialize plugin system
     this.plugins = new PluginRegistry();
-    this.stamps = new StampsModule(this.plugins);
+    this.stamps = new StampsModule(this.plugins, apiClient);
     this.proofs = new ProofsModule(this.plugins, apiClient);
   }
 }

--- a/src/AstralSDK.ts
+++ b/src/AstralSDK.ts
@@ -105,13 +105,12 @@ export class AstralSDK {
       signer: config.signer,
     });
 
-    // Initialize API client for hosted verification (optional)
-    const apiClient = config.apiKey
-      ? new AstralApiClient({
-          baseURL: config.apiUrl ?? 'https://api.astral.global',
-          apiKey: config.apiKey,
-        })
-      : undefined;
+    // Initialize API client for hosted verification
+    // API key is optional (throttled to 100 req/hour without one)
+    const apiClient = new AstralApiClient({
+      baseURL: config.apiUrl ?? 'https://api.astral.global',
+      apiKey: config.apiKey,
+    });
 
     // Initialize plugin system
     this.plugins = new PluginRegistry();

--- a/src/AstralSDK.ts
+++ b/src/AstralSDK.ts
@@ -32,6 +32,7 @@ import { ComputeModule } from './compute';
 import { StampsModule } from './stamps';
 import { ProofsModule } from './proofs';
 import { PluginRegistry } from './plugins/registry';
+import { AstralApiClient } from './api/AstralApiClient';
 import { AstralConfig } from './core/types';
 
 /**
@@ -104,9 +105,17 @@ export class AstralSDK {
       signer: config.signer,
     });
 
+    // Initialize API client for hosted verification (optional)
+    const apiClient = config.apiKey
+      ? new AstralApiClient({
+          baseURL: config.apiUrl ?? 'https://api.astral.global',
+          apiKey: config.apiKey,
+        })
+      : undefined;
+
     // Initialize plugin system
     this.plugins = new PluginRegistry();
     this.stamps = new StampsModule(this.plugins);
-    this.proofs = new ProofsModule(this.plugins);
+    this.proofs = new ProofsModule(this.plugins, apiClient);
   }
 }

--- a/src/api/AstralApiClient.ts
+++ b/src/api/AstralApiClient.ts
@@ -113,6 +113,18 @@ export class AstralApiClient {
   }
 
   /**
+   * Throws if no API key is configured. Called by methods that require auth.
+   */
+  private requireApiKey(method: string): void {
+    if (!this.apiKey) {
+      throw new AstralAPIError(
+        `${method} requires an API key. Set apiKey in AstralApiClient config.`,
+        401
+      );
+    }
+  }
+
+  /**
    * Makes a request to the Astral API.
    *
    * @param method - HTTP method (GET, POST, etc.)
@@ -409,6 +421,7 @@ export class AstralApiClient {
     proof: LocationProof,
     options?: VerifyProofOptions
   ): Promise<VerifiedLocationProof> {
+    this.requireApiKey('verifyProof');
     return this.request<VerifiedLocationProof>('POST', '/verify/v0/proof', {
       proof,
       options,
@@ -428,6 +441,7 @@ export class AstralApiClient {
    * @throws AstralAPIError if the service request fails
    */
   async verifyStamp(stamp: LocationStamp): Promise<StampVerificationResult> {
+    this.requireApiKey('verifyStamp');
     return this.request<StampVerificationResult>('POST', '/verify/v0/stamp', {
       stamp,
     });

--- a/src/api/AstralApiClient.ts
+++ b/src/api/AstralApiClient.ts
@@ -14,6 +14,13 @@ import {
   LocationAttestationCollection,
   AttestationQuery,
 } from '../core/types';
+import type {
+  LocationProof,
+  LocationStamp,
+  StampVerificationResult,
+  VerifiedLocationProof,
+  PluginMetadata,
+} from '../plugins/types';
 
 /**
  * Configuration options for the AstralApiClient
@@ -53,6 +60,20 @@ export interface AstralApiConfig {
   features?: {
     [featureName: string]: boolean;
   };
+}
+
+/**
+ * Options for proof verification via the hosted service.
+ */
+export interface VerifyProofOptions {
+  /** Chain ID for the EAS attestation (defaults to service config) */
+  chainId?: number;
+  /** Whether to submit the attestation onchain */
+  submitOnchain?: boolean;
+  /** EAS schema UID override */
+  schema?: string;
+  /** Attestation recipient address */
+  recipient?: string;
 }
 
 /**
@@ -364,5 +385,64 @@ export class AstralApiClient {
       undefined,
       { proof }
     );
+  }
+
+  // ============================================
+  // Location proof verification (hosted service)
+  // ============================================
+
+  /**
+   * Verifies a location proof via the hosted verification service.
+   *
+   * Sends the proof to the Astral service for TEE-hosted evaluation.
+   * The service verifies each stamp, evaluates the proof against the claim,
+   * and returns a VerifiedLocationProof with an EAS attestation.
+   *
+   * Requires an API key (set via constructor config).
+   *
+   * @param proof - The location proof (claim + stamps) to verify
+   * @param options - Optional verification parameters
+   * @returns Verified proof with credibility assessment and EAS attestation
+   * @throws AstralAPIError if the service request fails
+   */
+  async verifyProof(
+    proof: LocationProof,
+    options?: VerifyProofOptions
+  ): Promise<VerifiedLocationProof> {
+    return this.request<VerifiedLocationProof>('POST', '/verify/v0/proof', {
+      proof,
+      options,
+    });
+  }
+
+  /**
+   * Verifies a single stamp's internal validity via the hosted service.
+   *
+   * Checks signatures, structure, and signal consistency for one stamp
+   * without evaluating it against a claim.
+   *
+   * Requires an API key (set via constructor config).
+   *
+   * @param stamp - The location stamp to verify
+   * @returns Verification result with validity details
+   * @throws AstralAPIError if the service request fails
+   */
+  async verifyStamp(stamp: LocationStamp): Promise<StampVerificationResult> {
+    return this.request<StampVerificationResult>('POST', '/verify/v0/stamp', {
+      stamp,
+    });
+  }
+
+  /**
+   * Lists plugins available on the hosted verification service.
+   *
+   * Returns metadata for each plugin the service can use to verify stamps.
+   * Useful for discovering which proof-of-location systems the service supports.
+   *
+   * @returns Array of plugin metadata
+   * @throws AstralAPIError if the service request fails
+   */
+  async listRemotePlugins(): Promise<PluginMetadata[]> {
+    return this.request<PluginMetadata[]>('GET', '/verify/v0/plugins');
   }
 }

--- a/src/api/AstralApiClient.ts
+++ b/src/api/AstralApiClient.ts
@@ -113,18 +113,6 @@ export class AstralApiClient {
   }
 
   /**
-   * Throws if no API key is configured. Called by methods that require auth.
-   */
-  private requireApiKey(method: string): void {
-    if (!this.apiKey) {
-      throw new AstralAPIError(
-        `${method} requires an API key. Set apiKey in AstralApiClient config.`,
-        401
-      );
-    }
-  }
-
-  /**
    * Makes a request to the Astral API.
    *
    * @param method - HTTP method (GET, POST, etc.)
@@ -410,7 +398,8 @@ export class AstralApiClient {
    * The service verifies each stamp, evaluates the proof against the claim,
    * and returns a VerifiedLocationProof with an EAS attestation.
    *
-   * Requires an API key (set via constructor config).
+   * An API key is optional but recommended — without one, requests are
+   * throttled to 100/hour.
    *
    * @param proof - The location proof (claim + stamps) to verify
    * @param options - Optional verification parameters
@@ -421,7 +410,6 @@ export class AstralApiClient {
     proof: LocationProof,
     options?: VerifyProofOptions
   ): Promise<VerifiedLocationProof> {
-    this.requireApiKey('verifyProof');
     return this.request<VerifiedLocationProof>('POST', '/verify/v0/proof', {
       proof,
       options,
@@ -434,14 +422,14 @@ export class AstralApiClient {
    * Checks signatures, structure, and signal consistency for one stamp
    * without evaluating it against a claim.
    *
-   * Requires an API key (set via constructor config).
+   * An API key is optional but recommended — without one, requests are
+   * throttled to 100/hour.
    *
    * @param stamp - The location stamp to verify
    * @returns Verification result with validity details
    * @throws AstralAPIError if the service request fails
    */
   async verifyStamp(stamp: LocationStamp): Promise<StampVerificationResult> {
-    this.requireApiKey('verifyStamp');
     return this.request<StampVerificationResult>('POST', '/verify/v0/stamp', {
       stamp,
     });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -518,6 +518,8 @@ export interface AstralConfig {
   readonly signer?: unknown; // Will be refined to ethers.Signer
   readonly provider?: unknown; // Will be refined to ethers.Provider
   readonly apiUrl?: string;
+  /** API key for the hosted verification service */
+  readonly apiKey?: string;
   readonly debug?: boolean;
   // Location-specific (inherited from AstralSDKConfig)
   readonly defaultChain?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,7 @@ export { OffchainSigner } from './eas/OffchainSigner';
 export { OnchainRegistrar } from './eas/OnchainRegistrar';
 export { SchemaEncoder } from './eas/SchemaEncoder';
 export { AstralApiClient } from './api/AstralApiClient';
+export type { VerifyProofOptions } from './api/AstralApiClient';
 export { StorageAdapter } from './storage/StorageAdapter';
 
 // Utils exports

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export type {
   CredibilityVector,
   StampResult,
   CorrelationAssessment,
+  VerifiedLocationProof,
   SubjectIdentifier,
   TimeBounds,
   LocationData,
@@ -76,6 +77,7 @@ export {
   isGeoJSONGeometry,
   isMultiStampProof,
   isUnsignedStamp,
+  isVerifiedLocationProof,
 } from './plugins';
 
 // Stamps and Proofs modules

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -36,6 +36,7 @@ export type {
   CredibilityVector,
   StampResult,
   CorrelationAssessment,
+  VerifiedLocationProof,
 
   // Shared types
   SubjectIdentifier,
@@ -45,7 +46,13 @@ export type {
   LPGeometryType,
 } from './types';
 
-export { getPluginMetadata, isGeoJSONGeometry, isMultiStampProof, isUnsignedStamp } from './types';
+export {
+  getPluginMetadata,
+  isGeoJSONGeometry,
+  isMultiStampProof,
+  isUnsignedStamp,
+  isVerifiedLocationProof,
+} from './types';
 
 // Mock plugin
 export { MockPlugin } from './mock';

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -430,7 +430,7 @@ export interface VerifiedLocationProof {
   /** Full multidimensional credibility assessment (no summary score) */
   credibility: CredibilityVector;
 
-  /** EAS attestation signed by the verifier */
+  /** EAS attestation signed by the verifier (field names match EAS AttestationStruct) */
   attestation: {
     /** EAS attestation UID */
     uid: string;
@@ -446,17 +446,21 @@ export interface VerifiedLocationProof {
     refUID: string;
     /** ABI-encoded attestation data */
     data: string;
-    /** When the attestation was created (Unix timestamp) */
-    timestamp: number;
+    /** When the attestation was created (Unix timestamp, matches EAS `time` field) */
+    time: number;
     /** When the attestation expires (0 = never) */
     expirationTime: number;
     /** When revoked (0 = not revoked) */
     revocationTime: number;
-    /** Chain where the attestation is valid */
-    chainId: number;
-    /** Signature for offchain attestations */
+    /**
+     * Signature for offchain attestations.
+     * Undefined for onchain attestations (verified via transaction instead).
+     */
     signature?: string;
   };
+
+  /** Chain where the attestation was created (contextual, not part of EAS struct) */
+  chainId?: number;
 
   /** TEE remote attestation, if available from the execution environment */
   remoteAttestation?: {
@@ -482,7 +486,13 @@ export interface VerifiedLocationProof {
 export function isVerifiedLocationProof(
   result: CredibilityVector | VerifiedLocationProof
 ): result is VerifiedLocationProof {
-  return 'attestation' in result && 'proof' in result;
+  return (
+    'attestation' in result &&
+    'proof' in result &&
+    'evaluationMethod' in result &&
+    typeof (result as VerifiedLocationProof).attestation === 'object' &&
+    'uid' in (result as VerifiedLocationProof).attestation
+  );
 }
 
 // ============================================

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -459,6 +459,21 @@ export interface VerifiedLocationProof {
     signature?: string;
   };
 
+  /**
+   * Delegated attestation data for onchain submission via `attestByDelegation`.
+   * Present when the verifier signs for delegated submission (TEE mode).
+   */
+  delegatedAttestation?: {
+    /** EIP-712 signature for delegated attestation */
+    signature: string;
+    /** Address of the delegated attester (same as attestation.attester) */
+    attester: string;
+    /** Unix timestamp deadline for submission */
+    deadline: number;
+    /** Nonce used in signature (needed for EAS contract verification) */
+    nonce: number;
+  };
+
   /** Chain where the attestation was created (contextual, not part of EAS struct) */
   chainId?: number;
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -406,6 +406,85 @@ export interface CredibilityVector {
   };
 }
 
+/**
+ * Verified Location Proof — the complete output of TEE/ZK verification.
+ *
+ * Contains everything needed to evaluate and verify a location proof:
+ * the original proof, the full credibility assessment, and the EAS
+ * attestation signed by the verifier (e.g., Astral TEE).
+ *
+ * Third parties can:
+ * 1. Check `attestation.attester` — do I trust this verifier?
+ * 2. Verify `attestation.signature` — is the attestation authentic?
+ * 3. Inspect `credibility.dimensions` — apply my own trust model
+ * 4. Optionally re-run verification on `proof` to validate the attester's work
+ *
+ * The attestation includes the FULL proof and credibility data (not hashes
+ * or URIs) for v0. Future versions may optimize with hashes + offchain
+ * storage for privacy and size.
+ */
+export interface VerifiedLocationProof {
+  /** The original proof that was verified (claim + stamps) */
+  proof: LocationProof;
+
+  /** Full multidimensional credibility assessment (no summary score) */
+  credibility: CredibilityVector;
+
+  /** EAS attestation signed by the verifier */
+  attestation: {
+    /** EAS attestation UID */
+    uid: string;
+    /** Schema UID used for this attestation */
+    schema: string;
+    /** Address of the verifier who signed (e.g., Astral TEE signer) */
+    attester: string;
+    /** Recipient of the attestation */
+    recipient: string;
+    /** Whether the attestation can be revoked */
+    revocable: boolean;
+    /** Reference to another attestation (bytes32, 0x0 if none) */
+    refUID: string;
+    /** ABI-encoded attestation data */
+    data: string;
+    /** When the attestation was created (Unix timestamp) */
+    timestamp: number;
+    /** When the attestation expires (0 = never) */
+    expirationTime: number;
+    /** When revoked (0 = not revoked) */
+    revocationTime: number;
+    /** Chain where the attestation is valid */
+    chainId: number;
+    /** Signature for offchain attestations */
+    signature?: string;
+  };
+
+  /** TEE remote attestation, if available from the execution environment */
+  remoteAttestation?: {
+    /** TEE attestation quote */
+    quote: string;
+    /** TEE platform identifier (e.g., "sgx", "tdx", "sev") */
+    platform: string;
+    /** Additional platform-specific metadata */
+    metadata?: Record<string, unknown>;
+  };
+
+  /** Identifier for the evaluation method (e.g., "astral-v0.3.0-tee") */
+  evaluationMethod: string;
+
+  /** When evaluation was performed (Unix seconds) */
+  evaluatedAt: number;
+}
+
+/**
+ * Type guard: check if a verification result is a VerifiedLocationProof
+ * (from TEE/ZK mode) rather than a CredibilityVector (from local mode).
+ */
+export function isVerifiedLocationProof(
+  result: CredibilityVector | VerifiedLocationProof
+): result is VerifiedLocationProof {
+  return 'attestation' in result && 'proof' in result;
+}
+
 // ============================================
 // Plugin interface
 // ============================================

--- a/src/proofs/ProofsModule.ts
+++ b/src/proofs/ProofsModule.ts
@@ -8,6 +8,8 @@
  */
 
 import { PluginRegistry } from '../plugins/registry';
+import type { AstralApiClient } from '../api/AstralApiClient';
+import type { VerifyProofOptions } from '../api/AstralApiClient';
 import type {
   LocationClaim,
   LocationStamp,
@@ -15,6 +17,7 @@ import type {
   LocationData,
   StampVerificationResult,
   CredibilityVector,
+  VerifiedLocationProof,
   StampResult,
 } from '../plugins/types';
 
@@ -71,7 +74,10 @@ function extractCoordinates(location: LocationData): [number, number] | null {
  * ```
  */
 export class ProofsModule {
-  constructor(private readonly registry: PluginRegistry) {}
+  constructor(
+    private readonly registry: PluginRegistry,
+    private readonly apiClient?: AstralApiClient
+  ) {}
 
   /**
    * Example weighting function: Basic support ratio.
@@ -129,37 +135,56 @@ export class ProofsModule {
    * @param proof - The proof to verify
    * @param options - Verification options
    * @param options.mode - Where to run verification:
-   *   - 'local' (default): Run in current environment
-   *   - 'tee': Run in TEE via hosted service (returns EAS attestation)
+   *   - 'local' (default): Run in current environment, returns CredibilityVector
+   *   - 'tee': Run in TEE via hosted service, returns VerifiedLocationProof with EAS attestation
    *   - 'zk': Run in ZK prover (future)
-   * @param options.endpoint - API endpoint for hosted verification (mode: 'tee' or 'zk')
-   *   - Allows per-call endpoint specification (staging, production, custom)
-   *   - Example: 'https://verify.astral.global' or 'https://verify-staging.astral.global'
-   * @returns Credibility vector with confidence score, stamp results, and correlation analysis
+   * @param options.chainId - Chain ID for EAS attestation (TEE mode only)
+   * @param options.submitOnchain - Submit attestation onchain (TEE mode only)
+   * @param options.schema - EAS schema UID override (TEE mode only)
+   * @param options.recipient - Attestation recipient address (TEE mode only)
+   * @returns CredibilityVector for local mode, VerifiedLocationProof for TEE mode.
+   *   Use `isVerifiedLocationProof()` to narrow the return type.
    *
    * @example
    * ```typescript
    * // Verify locally first (free, fast)
-   * const local = await proofs.verify(proof, { mode: 'local' });
+   * const local = await proofs.verify(proof);
    * if (local.dimensions.spatial.withinRadiusFraction < 0.8) return;
    *
-   * // Then get TEE attestation (costs money, high assurance)
-   * const tee = await proofs.verify(proof, {
-   *   mode: 'tee',
-   *   endpoint: 'https://verify.astral.global'
-   * });
+   * // Then get TEE attestation (requires API key)
+   * const result = await proofs.verify(proof, { mode: 'tee' });
+   * if (isVerifiedLocationProof(result)) {
+   *   console.log('EAS attestation:', result.attestation.uid);
+   * }
    * ```
    */
   async verify(
     proof: LocationProof,
-    options?: { mode?: 'local' | 'tee' | 'zk'; endpoint?: string }
-  ): Promise<CredibilityVector> {
+    options: { mode: 'tee' } & VerifyProofOptions
+  ): Promise<VerifiedLocationProof>;
+  async verify(
+    proof: LocationProof,
+    options?: { mode?: 'local' | 'zk' }
+  ): Promise<CredibilityVector>;
+  async verify(
+    proof: LocationProof,
+    options?: { mode?: 'local' | 'tee' | 'zk' } & VerifyProofOptions
+  ): Promise<CredibilityVector | VerifiedLocationProof> {
     const mode = options?.mode ?? 'local';
 
     if (mode === 'tee') {
-      // TODO(#45): Wire TEE verification via hosted service
-      // Eigen deployment is ready, needs SDK integration
-      throw new Error('TEE verification not yet implemented — use local verification');
+      if (!this.apiClient) {
+        throw new Error(
+          'TEE verification requires an API client. Configure apiKey in AstralSDK options.'
+        );
+      }
+      const { chainId, submitOnchain, schema, recipient } = options ?? {};
+      return this.apiClient.verifyProof(proof, {
+        chainId,
+        submitOnchain,
+        schema,
+        recipient,
+      });
     }
     if (mode === 'zk') {
       throw new Error('ZK verification not yet implemented');

--- a/src/proofs/ProofsModule.ts
+++ b/src/proofs/ProofsModule.ts
@@ -151,7 +151,7 @@ export class ProofsModule {
    * const local = await proofs.verify(proof);
    * if (local.dimensions.spatial.withinRadiusFraction < 0.8) return;
    *
-   * // Then get TEE attestation (requires API key)
+   * // Then get TEE attestation (API key optional, throttled without one)
    * const result = await proofs.verify(proof, { mode: 'tee' });
    * if (isVerifiedLocationProof(result)) {
    *   console.log('EAS attestation:', result.attestation.uid);
@@ -175,7 +175,8 @@ export class ProofsModule {
     if (mode === 'tee') {
       if (!this.apiClient) {
         throw new Error(
-          'TEE verification requires an API client. Configure apiKey in AstralSDK options.'
+          'TEE verification requires a hosted service connection. ' +
+            'Use AstralSDK (which configures this automatically) or pass an AstralApiClient.'
         );
       }
       const { chainId, submitOnchain, schema, recipient } = options ?? {};

--- a/src/stamps/StampsModule.ts
+++ b/src/stamps/StampsModule.ts
@@ -9,6 +9,7 @@
  */
 
 import { PluginRegistry } from '../plugins/registry';
+import type { AstralApiClient } from '../api/AstralApiClient';
 import type {
   LocationStamp,
   UnsignedLocationStamp,
@@ -44,7 +45,10 @@ export interface StampsSignOptions {
  * ```
  */
 export class StampsModule {
-  constructor(private readonly registry: PluginRegistry) {}
+  constructor(
+    private readonly registry: PluginRegistry,
+    private readonly apiClient?: AstralApiClient
+  ) {}
 
   /**
    * Collect raw signals from one or more plugins.
@@ -98,14 +102,26 @@ export class StampsModule {
   }
 
   /**
-   * Verify a stamp's internal validity using its plugin's verify method.
+   * Verify a stamp's internal validity.
+   *
+   * @param stamp - The stamp to verify
+   * @param options - Verification options
+   * @param options.hosted - If true, verify via the hosted service instead of locally.
+   *   The hosted service doesn't require an API key but is throttled without one.
+   * @returns Verification result with signature, structure, and signal checks
    */
   async verify(
     stamp: LocationStamp,
     options?: { hosted?: boolean }
   ): Promise<StampVerificationResult> {
     if (options?.hosted) {
-      throw new Error('Hosted verification not yet implemented — use local verification');
+      if (!this.apiClient) {
+        throw new Error(
+          'Hosted verification requires a service connection. ' +
+            'Use AstralSDK (which configures this automatically) or pass an AstralApiClient.'
+        );
+      }
+      return this.apiClient.verifyStamp(stamp);
     }
 
     const plugin = this.registry.get(stamp.plugin);

--- a/test/proofs/ProofsModule.test.ts
+++ b/test/proofs/ProofsModule.test.ts
@@ -224,7 +224,7 @@ describe('ProofsModule', () => {
         expect(result.dimensions.validity.signaturesValidFraction).toBe(1);
       });
 
-      it('throws for TEE verification (not yet implemented)', async () => {
+      it('throws for TEE verification without API client configured', async () => {
         registry.register(createVerifyPlugin('mock'));
         const proof: LocationProof = {
           claim: baseClaim,
@@ -232,7 +232,7 @@ describe('ProofsModule', () => {
         };
 
         await expect(proofs.verify(proof, { mode: 'tee' })).rejects.toThrow(
-          'TEE verification not yet implemented'
+          'TEE verification requires an API client'
         );
       });
 

--- a/test/proofs/ProofsModule.test.ts
+++ b/test/proofs/ProofsModule.test.ts
@@ -232,7 +232,7 @@ describe('ProofsModule', () => {
         };
 
         await expect(proofs.verify(proof, { mode: 'tee' })).rejects.toThrow(
-          'TEE verification requires an API client'
+          'TEE verification requires a hosted service connection'
         );
       });
 

--- a/test/stamps/StampsModule.test.ts
+++ b/test/stamps/StampsModule.test.ts
@@ -164,10 +164,10 @@ describe('StampsModule', () => {
       await expect(stamps.verify(noVerifyStamp)).rejects.toThrow('does not implement verify()');
     });
 
-    it('throws for hosted verification (not yet implemented)', async () => {
+    it('throws for hosted verification without API client configured', async () => {
       registry.register(fullPlugin());
       await expect(stamps.verify(mockSigned, { hosted: true })).rejects.toThrow(
-        'Hosted verification not yet implemented'
+        'Hosted verification requires a service connection'
       );
     });
   });


### PR DESCRIPTION
## Summary

Wire the SDK to call the hosted verification service (`/verify/v0/*`) for TEE-mode proof and stamp verification, and align types across SDK and service.

This PR will be built up incrementally with commits per phase:

- [x] **Phase 1:** Add `VerifiedLocationProof` type (complete attestation structure)
- [ ] **Phase 2:** Add `verifyProof()` / `verifyStamp()` to `AstralApiClient`
- [ ] **Phase 3:** Wire `ProofsModule.verify()` TEE mode to API client
- [ ] **Phase 4:** Wire `StampsModule.verify()` hosted mode to API client
- [ ] **Phase 5:** Align service response with `VerifiedLocationProof` type
- [ ] **Phase 6:** Plugin consolidation (import SDK plugins into service)
- [ ] **Phase 7:** Tests for SDK-service integration

## Context

The SDK has `mode: 'local' | 'tee' | 'zk'` on `proofs.verify()` but TEE mode was a TODO (#45). This PR implements the HTTP client integration so `mode: 'tee'` calls the hosted service and returns a `VerifiedLocationProof` — the full proof + credibility vector + EAS attestation, all signed by the Astral TEE.

**Key design decisions:**
- Local mode returns `CredibilityVector` (lightweight, no attestation)
- TEE mode returns `VerifiedLocationProof` (complete, with EAS attestation)
- No summary confidence score — multidimensional credibility only (per research doc)
- Full data in attestations for v0 (optimize with hashes/URIs later)

## Related

- Closes #45
- Refs #60 (W3C VC alignment — future work)
- Plan: `~/.claude/plans/service-integration-implementation-plan.md`

## Test plan

- [ ] Typecheck passes after each commit
- [ ] All existing tests still pass (402 tests)
- [ ] New unit tests for API client verify methods
- [ ] New unit tests for TEE/hosted mode in ProofsModule and StampsModule
- [ ] Integration test: SDK → service round-trip