### PR TITLE
feat(compute): add VerifiedProofInput type and normalize support

### DIFF
--- a/src/compute/ComputeModule.ts
+++ b/src/compute/ComputeModule.ts
@@ -74,7 +74,7 @@ export class ComputeModule {
       return { uid: input };
     }
     // Verified proof input — pass through as-is
-    if (typeof input === 'object' && 'verifiedProof' in input) {
+    if (typeof input === 'object' && 'verifiedProof' in input && !('type' in input)) {
       return input as object;
     }
     // GeoJSON Feature - extract geometry

--- a/src/compute/ComputeModule.ts
+++ b/src/compute/ComputeModule.ts
@@ -73,6 +73,10 @@ export class ComputeModule {
     if (typeof input === 'string') {
       return { uid: input };
     }
+    // Verified proof input — pass through as-is
+    if (typeof input === 'object' && 'verifiedProof' in input) {
+      return input as object;
+    }
     // GeoJSON Feature - extract geometry
     if (
       typeof input === 'object' &&

--- a/src/compute/index.ts
+++ b/src/compute/index.ts
@@ -11,6 +11,8 @@ export type {
   RawGeometryInput,
   OnchainInput,
   OffchainInput,
+  VerifiedProofInput,
+  ProofInputContext,
   ComputeOptions,
   DelegatedAttestation,
   DelegatedAttestationMessage,

--- a/src/compute/types.ts
+++ b/src/compute/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Geometry } from 'geojson';
+import type { VerifiedLocationProof } from '../plugins/types';
 
 /**
  * Raw GeoJSON geometry input
@@ -28,13 +29,22 @@ export interface OffchainInput {
 }
 
 /**
+ * Input from a verified location proof.
+ * Geometry is extracted from the proof's claim; the attestation UID is used as ref.
+ */
+export interface VerifiedProofInput {
+  readonly verifiedProof: VerifiedLocationProof;
+}
+
+/**
  * Input types for compute operations
  * - string: Direct attestation UID
  * - RawGeometryInput: GeoJSON Geometry
  * - OnchainInput: Reference to onchain attestation
  * - OffchainInput: Reference to offchain attestation with URI
+ * - VerifiedProofInput: Geometry from a verified location proof
  */
-export type Input = string | RawGeometryInput | OnchainInput | OffchainInput;
+export type Input = string | RawGeometryInput | OnchainInput | OffchainInput | VerifiedProofInput;
 
 /**
  * Options for compute operations
@@ -98,6 +108,18 @@ export interface DelegatedAttestationObject {
 }
 
 /**
+ * Proof metadata carried through from a verified proof input.
+ * Loose typing (unknown) for forward compatibility with evolving credibility/claim shapes.
+ */
+export interface ProofInputContext {
+  readonly ref: string;
+  readonly credibility: unknown;
+  readonly claim: unknown;
+  readonly evaluatedAt: number;
+  readonly evaluationMethod: string;
+}
+
+/**
  * Result for numeric compute operations (distance, area, length)
  */
 export interface NumericComputeResult {
@@ -108,6 +130,7 @@ export interface NumericComputeResult {
   readonly inputRefs: string[];
   readonly attestation: AttestationObject;
   readonly delegatedAttestation: DelegatedAttestationObject;
+  readonly proofInputs?: ProofInputContext[];
 }
 
 /**
@@ -120,6 +143,7 @@ export interface BooleanComputeResult {
   readonly inputRefs: string[];
   readonly attestation: AttestationObject;
   readonly delegatedAttestation: DelegatedAttestationObject;
+  readonly proofInputs?: ProofInputContext[];
 }
 
 /**

--- a/src/compute/types.ts
+++ b/src/compute/types.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Geometry } from 'geojson';
-import type { VerifiedLocationProof } from '../plugins/types';
+import type { VerifiedLocationProof, CredibilityVector, LocationClaim } from '../plugins/types';
 
 /**
  * Raw GeoJSON geometry input
@@ -109,12 +109,11 @@ export interface DelegatedAttestationObject {
 
 /**
  * Proof metadata carried through from a verified proof input.
- * Loose typing (unknown) for forward compatibility with evolving credibility/claim shapes.
  */
 export interface ProofInputContext {
   readonly ref: string;
-  readonly credibility: unknown;
-  readonly claim: unknown;
+  readonly credibility: CredibilityVector;
+  readonly claim: LocationClaim;
   readonly evaluatedAt: number;
   readonly evaluationMethod: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,8 @@ export type {
 // Compute types
 export type {
   Input,
+  VerifiedProofInput,
+  ProofInputContext,
   ComputeOptions,
   NumericComputeResult,
   BooleanComputeResult,


### PR DESCRIPTION
## Summary

- Adds `VerifiedProofInput` as a new compute input type wrapping `VerifiedLocationProof` from plugins
- Extends `Input` union so devs can pass verified proofs directly to `distance()`, `within()`, etc.
- Adds `ProofInputContext` type (loose typing with `unknown` for forward compat) to result types
- Handles `verifiedProof` in `ComputeModule.normalizeInput()` — passes through to service as-is

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [ ] Integration test with running service (verified proof → compute distance)